### PR TITLE
Merge Dev into REL 

### DIFF
--- a/firmware/LICENSE.imagination
+++ b/firmware/LICENSE.imagination
@@ -1,0 +1,27 @@
+Copyright (c) 2015 Imagination Technologies Limited and/or its affiliated group companies
+All rights reserved.
+
+Redistribution and use in binary form only without modification is permitted
+provided that the following conditions are met:
+
+1. Redistributions must retain the above copyright notice and the following
+disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+2. Neither the name of the copyright holder nor the names of its suppliers may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+3. No reverse engineering, decompilation, or disassembly of this software is
+permitted.
+
+DISCLAIMER. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/80211_if.c
+++ b/src/80211_if.c
@@ -1465,7 +1465,9 @@ static void init_hw(struct ieee80211_hw *hw)
 
 static int ampdu_action(struct ieee80211_hw *hw,
 				struct ieee80211_vif *vif,
-				struct ieee80211_ampdu_params *params)
+				enum ieee80211_ampdu_mlme_action action,
+				struct ieee80211_sta *sta,
+				u16 tid, u16 *ssn, u8 buf_size, bool amsdu)
 {
 	int ret = 0;
 	unsigned int val = 0;
@@ -1474,14 +1476,14 @@ static int ampdu_action(struct ieee80211_hw *hw,
 	UCCP_DEBUG_80211IF("%s-80211IF: ampdu action started\n",
 			((struct mac80211_dev *)(hw->priv))->name);
 		/* TODO */
-	switch (params->action) {
+	switch (action) {
 	case IEEE80211_AMPDU_RX_START:
 		{
-		val = params->tid | TID_INITIATOR_AP;
+		val = tid | TID_INITIATOR_AP;
 		dev->tid_info[val].tid_state = TID_STATE_AGGR_START;
-		dev->tid_info[val].ssn = params->ssn;
+		dev->tid_info[val].ssn = *ssn;
 		uccp420wlan_prog_ba_session_data(1,
-						 params->tid,
+						 tid,
 						 &dev->tid_info[val].ssn,
 						 1,
 						 vif->addr,
@@ -1490,10 +1492,10 @@ static int ampdu_action(struct ieee80211_hw *hw,
 		break;
 	case IEEE80211_AMPDU_RX_STOP:
 		{
-		val = params->tid | TID_INITIATOR_AP;
+		val = tid | TID_INITIATOR_AP;
 		dev->tid_info[val].tid_state = TID_STATE_AGGR_STOP;
 		uccp420wlan_prog_ba_session_data(0,
-						 params->tid,
+						 tid,
 						 &dev->tid_info[val].ssn,
 						 1,
 						 vif->addr,
@@ -1502,24 +1504,24 @@ static int ampdu_action(struct ieee80211_hw *hw,
 		break;
 	case IEEE80211_AMPDU_TX_START:
 		{
-		val = params->tid | TID_INITIATOR_STA;
-		ieee80211_start_tx_ba_cb_irqsafe(vif, params->sta->addr, params->tid);
+		val = tid | TID_INITIATOR_STA;
+		ieee80211_start_tx_ba_cb_irqsafe(vif, sta->addr, tid);
 		dev->tid_info[val].tid_state = TID_STATE_AGGR_START;
-		dev->tid_info[val].ssn = params->ssn;
+		dev->tid_info[val].ssn = *ssn;
 		}
 		break;
 	case IEEE80211_AMPDU_TX_STOP_FLUSH:
 	case IEEE80211_AMPDU_TX_STOP_FLUSH_CONT:
 	case IEEE80211_AMPDU_TX_STOP_CONT:
 		{
-		val = params->tid | TID_INITIATOR_STA;
+		val = tid | TID_INITIATOR_STA;
 		dev->tid_info[val].tid_state = TID_STATE_AGGR_STOP;
-		ieee80211_stop_tx_ba_cb_irqsafe(vif, params->sta->addr, params->tid);
+		ieee80211_stop_tx_ba_cb_irqsafe(vif, sta->addr, tid);
 		}
 		break;
 	case IEEE80211_AMPDU_TX_OPERATIONAL:
 		{
-		val = params->tid | TID_INITIATOR_STA;
+		val = tid | TID_INITIATOR_STA;
 		dev->tid_info[val].tid_state = TID_STATE_AGGR_OPERATIONAL;
 		}
 		break;


### PR DESCRIPTION
* Revert "Fix errors/warnings while compiling against kmod-mac80211"

This is not recomended in the upstream as it is specific to
OpenWrt build. This break compatibility with CreatorDev/linux
repo.

This reverts commit e62baef655898526c69250bc63723241f3f4c46d.

* add firmware license text

Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>